### PR TITLE
Update source code scrolling

### DIFF
--- a/example/lib/ide/editor/editor.dart
+++ b/example/lib/ide/editor/editor.dart
@@ -397,33 +397,31 @@ class _IdeEditorState extends State<IdeEditor> {
         child: Focus(
           focusNode: _focusNode,
           autofocus: true,
-          child: InteractiveViewer(
-            constrained: false,
-            scaleEnabled: false,
-            child: MouseRegion(
-              onHover: _onHover,
-              onExit: (event) => _hoverOverlayController.hide(),
+          child: MouseRegion(
+            onHover: _onHover,
+            onExit: (event) => _hoverOverlayController.hide(),
+            child: OverlayPortal(
+              controller: _hoverOverlayController,
+              overlayChildBuilder: (context) => _buildHoverOverlay(),
               child: OverlayPortal(
-                controller: _hoverOverlayController,
-                overlayChildBuilder: (context) => _buildHoverOverlay(),
-                child: OverlayPortal(
-                  controller: _actionsOverlayController,
-                  overlayChildBuilder: (context) => _buildCodeActionsPopover(),
-                  child: Stack(
-                    children: [
-                      _buildCursorHoverLeader(),
-                      _buildCodeActionsLeader(),
-                      GestureDetector(
+                controller: _actionsOverlayController,
+                overlayChildBuilder: (context) => _buildCodeActionsPopover(),
+                child: Stack(
+                  children: [
+                    Positioned.fill(
+                      child: GestureDetector(
                         onTapUp: _onTapUp,
                         child: CodeLines(
                           key: _linesKey,
                           codeLines: _styledLines,
-                          indentLineColor: _lineColor,
+                          indentLineColor: indentLineColor,
                           baseTextStyle: _baseCodeStyle,
                         ),
                       ),
-                    ],
-                  ),
+                    ),
+                    _buildCursorHoverLeader(),
+                    _buildCodeActionsLeader(),
+                  ],
                 ),
               ),
             ),
@@ -601,5 +599,3 @@ const _baseCodeStyle = TextStyle(
   fontSize: 16,
   fontWeight: FontWeight.w900,
 );
-
-const _lineColor = Color(0xFF333333);

--- a/example/lib/ide/theme.dart
+++ b/example/lib/ide/theme.dart
@@ -8,6 +8,9 @@ const dividerColor = Color(0xFF1C2022);
 const popoverBackgroundColor = Color(0xFF202224);
 const popoverBorderColor = Color(0xFF34353A);
 
+const lineColor = Color(0xFF1C2022);
+const indentLineColor = Color(0xFF333333);
+
 // Makes text light, for use during dark mode styling.
 final darkModeStyles = [
   StyleRule(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:ui';
 
 import 'package:example/ide/ide.dart';
 import 'package:example/ide/infrastructure/user_settings.dart';
@@ -8,8 +9,11 @@ import 'package:flutter/material.dart';
 
 void main() {
   runApp(
-    const MaterialApp(
-      home: _Screen(),
+    MaterialApp(
+      scrollBehavior: const MaterialScrollBehavior().copyWith(
+        dragDevices: PointerDeviceKind.values.toSet(),
+      ),
+      home: const _Screen(),
     ),
   );
 }


### PR DESCRIPTION
Currently, the line number indicator scroll horizontally with the source code.

This PR replaces the `InteractiveViewer` with a new `CodeScroller` widget, that uses Flutter's 2d scrolling API's. Now, the line number indicator scrolls vertically, but it's horizontally pinned.

https://github.com/user-attachments/assets/21867673-1843-44d2-b8a5-150c31128f85

