### PR TITLE
Add option to open multiple tabs (Resolves #23)

### DIFF
--- a/example/lib/ide/editor/code_layout.dart
+++ b/example/lib/ide/editor/code_layout.dart
@@ -37,6 +37,15 @@ class _CodeLinesState extends State<CodeLines> implements CodeLinesLayout {
   final _lineKeys = <int, GlobalKey>{};
 
   @override
+  void didUpdateWidget(covariant CodeLines oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (widget.codeLines.length != oldWidget.codeLines.length) {
+      _lineKeys.clear();
+    }
+  }
+
+  @override
   CodeRange? findWordBoundaryAtGlobalOffset(Offset globalOffset) {
     final line = _findLineLayoutAtGlobalOffset(globalOffset);
     if (line == null) {

--- a/example/lib/ide/editor/syntax_highlighting.dart
+++ b/example/lib/ide/editor/syntax_highlighting.dart
@@ -23,12 +23,12 @@ List<TextSpan> _breakUpTextSpanTreeIntoLines(
   styledLines.add(currentLine);
   int currentOffset = 0;
 
-  print("----------- PROCESSING SPANS ------------");
+  // print("----------- PROCESSING SPANS ------------");
   while (spanStack.isNotEmpty) {
-    print("----------------");
+    // print("----------------");
     final span = spanStack.removeAt(0);
-    print("Span:\n'${span.text}'");
-    print("-----");
+    // print("Span:\n'${span.text}'");
+    // print("-----");
 
     if (span.children != null) {
       // Push the children of this span onto the span stack so that they'll be
@@ -38,7 +38,7 @@ List<TextSpan> _breakUpTextSpanTreeIntoLines(
 
     if (span.text == null) {
       // There's no text in this span. Move on to the children, or later spans.
-      print("The span has no text. Moving to next span.");
+      // print("The span has no text. Moving to next span.");
       continue;
     }
 
@@ -46,11 +46,11 @@ List<TextSpan> _breakUpTextSpanTreeIntoLines(
     debugBuffer.writeln();
 
     final endOfSpan = currentOffset + span.text!.length;
-    print("Start of this span: $currentOffset");
-    print("End of this span: $endOfSpan");
+    // print("Start of this span: $currentOffset");
+    // print("End of this span: $endOfSpan");
 
     if (!span.text!.contains("\n")) {
-      print("This span has no newlines, appending to ongoing line.");
+      // print("This span has no newlines, appending to ongoing line.");
       // All the content in this span belongs to the current line. Append it.
       currentLine.children!.add(span);
       // print(
@@ -60,7 +60,7 @@ List<TextSpan> _breakUpTextSpanTreeIntoLines(
       continue;
     }
 
-    print("This span contains multiple lines of text...");
+    // print("This span contains multiple lines of text...");
     final lines = span.text!.split("\n");
     for (int i = 0; i < lines.length; i += 1) {
       final line = lines[i];
@@ -75,10 +75,10 @@ List<TextSpan> _breakUpTextSpanTreeIntoLines(
         // Write the current line to debug output for verification.
         final buffer = StringBuffer();
         currentLine.computeToPlainText(buffer);
-        print("COMMITTING LINE: '${buffer.toString()}'");
+        // print("COMMITTING LINE: '${buffer.toString()}'");
 
         // Create a new line to append remaining text.
-        print("STARTING NEW (BLANK) CODE LINE");
+        // print("STARTING NEW (BLANK) CODE LINE");
         currentLine = TextSpan(text: "", children: []);
         styledLines.add(currentLine);
       }

--- a/example/lib/ide/file_explorer/file_explorer.dart
+++ b/example/lib/ide/file_explorer/file_explorer.dart
@@ -35,14 +35,16 @@ class FileExplorer extends StatefulWidget {
   const FileExplorer({
     super.key,
     required this.directory,
-    required this.onFileOpenRequested,
+    required this.onFileTap,
+    required this.onFileDoubleTap,
     required this.lspClient,
   });
 
   final Directory directory;
   final LspClient lspClient;
 
-  final void Function(File file, OpenFileMode mode) onFileOpenRequested;
+  final void Function(File file) onFileTap;
+  final void Function(File file) onFileDoubleTap;
 
   @override
   State<FileExplorer> createState() => _FileExplorerState();
@@ -304,7 +306,7 @@ class _FileExplorerState extends State<FileExplorer> {
 
           if (node.isFile) {
             // Open document.
-            widget.onFileOpenRequested(node.asFile, OpenFileMode.replaceCurrentTab);
+            widget.onFileTap(node.asFile);
           }
         },
       ),
@@ -325,7 +327,7 @@ class _FileExplorerState extends State<FileExplorer> {
           });
 
           // Open document.
-          widget.onFileOpenRequested(node.asFile, OpenFileMode.newTab);
+          widget.onFileDoubleTap(node.asFile);
         },
       ),
     };
@@ -364,13 +366,4 @@ class _ClampedScrolling extends ScrollBehavior {
   ScrollPhysics getScrollPhysics(BuildContext context) {
     return const ClampingScrollPhysics();
   }
-}
-
-/// The way that the file should be opened.
-enum OpenFileMode {
-  /// Replace the current tab with the new file.
-  replaceCurrentTab,
-
-  /// Open the file in a new tab.
-  newTab,
 }

--- a/example/lib/ide/file_explorer/file_explorer.dart
+++ b/example/lib/ide/file_explorer/file_explorer.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 import 'dart:math';
 
 import 'package:example/ide/ide.dart';
-import 'package:example/ide/infrastructure/user_settings.dart';
 import 'package:example/lsp_exploration/lsp/lsp_client.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -43,7 +42,7 @@ class FileExplorer extends StatefulWidget {
   final Directory directory;
   final LspClient lspClient;
 
-  final void Function(File) onFileOpenRequested;
+  final void Function(File file, OpenFileMode mode) onFileOpenRequested;
 
   @override
   State<FileExplorer> createState() => _FileExplorerState();
@@ -305,7 +304,7 @@ class _FileExplorerState extends State<FileExplorer> {
 
           if (node.isFile) {
             // Open document.
-            widget.onFileOpenRequested(node.asFile);
+            widget.onFileOpenRequested(node.asFile, OpenFileMode.replaceCurrentTab);
           }
         },
       ),
@@ -326,7 +325,7 @@ class _FileExplorerState extends State<FileExplorer> {
           });
 
           // Open document.
-          widget.onFileOpenRequested(node.asFile);
+          widget.onFileOpenRequested(node.asFile, OpenFileMode.newTab);
         },
       ),
     };
@@ -365,4 +364,13 @@ class _ClampedScrolling extends ScrollBehavior {
   ScrollPhysics getScrollPhysics(BuildContext context) {
     return const ClampingScrollPhysics();
   }
+}
+
+/// The way that the file should be opened.
+enum OpenFileMode {
+  /// Replace the current tab with the new file.
+  replaceCurrentTab,
+
+  /// Open the file in a new tab.
+  newTab,
 }

--- a/example/lib/ide/ide_controller.dart
+++ b/example/lib/ide/ide_controller.dart
@@ -1,0 +1,223 @@
+import 'dart:collection';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+
+/// Provides the IDE functionallity, like opening and editing files.
+///
+/// Holds the list of open editors and the active editor.
+class IdeController {
+  /// The list of open editors and the active editor index.
+  ///
+  /// An editor is a view that allows the user to edit a file.
+  ///
+  /// It's separated from the [openFiles] so we can implement, in the future,
+  /// multiple editors for the same file. For example, open two editors side by side.
+  ValueListenable<IdeEditors> get editorData => _editorData;
+  final ValueNotifier<IdeEditors> _editorData = ValueNotifier(IdeEditors(openEditors: []));
+
+  /// The files that have at least one editor open.
+  Set<IdeFile> get openFiles => _openFiles;
+  final Set<IdeFile> _openFiles = {};
+
+  /// Maps the file URI to the opened editors for that file.
+  final _fileUriToOpenedEditors = <String, List<IdeFileEditor>>{};
+
+  /// Maps the file URI to the opened file.
+  final _fileUriToIdeFile = <String, IdeFile>{};
+
+  /// Opens the file with the given URI at the active editor.
+  ///
+  /// If there is no active editor, opens a new editor.
+  ///
+  /// If the file is already open in another editor, shows the existing editor.
+  Future<void> openFileAtActiveEditor(String fileUri) async {
+    if (showExistingEditorForFile(fileUri)) {
+      // The file is already open in another editor. Fizzle.
+      return;
+    }
+
+    await _loadFile(fileUri);
+
+    final activeEditorIndex = _editorData.value.activeEditorIndex;
+    if (activeEditorIndex != null) {
+      // There is an open editor. Close it.
+      closeEditorAtIndex(activeEditorIndex);
+    }
+
+    await _openFile(fileUri, activeEditorIndex ?? 0);
+  }
+
+  /// Opens the file with the given URI at a new editor.
+  ///
+  /// If the file is already open in another editor, shows the existing editor.
+  Future<void> openFileAtNewTab(String fileUri) async {
+    if (showExistingEditorForFile(fileUri)) {
+      return;
+    }
+
+    await _loadFile(fileUri);
+
+    await _openFile(fileUri, _editorData.value.openEditors.length);
+  }
+
+  /// Shows the existing editor for the file with the given URI, if any.
+  ///
+  /// Returns `true` if there is an existing editor for the file and `false` otherwise.
+  bool showExistingEditorForFile(String fileUri) {
+    final editorList = _fileUriToOpenedEditors[fileUri];
+    if (editorList == null || editorList.isEmpty) {
+      return false;
+    }
+
+    // Show the existing editor.
+    final editor = editorList.first;
+    final editorIndex = _editorData.value.openEditors.indexOf(editor);
+    _editorData.value = IdeEditors(
+      openEditors: _editorData.value.openEditors,
+      activeEditorIndex: editorIndex,
+    );
+
+    return true;
+  }
+
+  /// Closes the editor at the given index.
+  ///
+  /// If the editor is the active editor, updates the active editor with the following rules:
+  ///
+  /// - If there are no other open editors, sets the active editor to `null`.
+  /// - If there is an editor after the closed editor, makes it the active editor.
+  /// - If there is an editor before the closed editor, makes it the active editor.
+  void closeEditorAtIndex(int index) {
+    final editor = _editorData.value.openEditors[index];
+    final fileUri = editor.fileUri;
+    final isActiveEditor = _editorData.value.activeEditorIndex == index;
+
+    // Updates the editor list.
+    final newList = _editorData.value.openEditors.where((e) => e != editor).toList();
+    int? newActiveEditorIndex;
+    if (isActiveEditor) {
+      // Updates the active editor.
+      if (newList.isEmpty) {
+        newActiveEditorIndex = null;
+      } else if (index < newList.length) {
+        newActiveEditorIndex = index;
+      } else {
+        newActiveEditorIndex = index - 1;
+      }
+    }
+
+    _editorData.value = IdeEditors(
+      openEditors: UnmodifiableListView(newList),
+      activeEditorIndex: newActiveEditorIndex,
+    );
+
+    // Remove the editor from the list of open editors for the file.
+    final openEditorForFile = _fileUriToOpenedEditors[fileUri]!;
+    openEditorForFile.remove(editor);
+
+    if (openEditorForFile.isEmpty) {
+      // The file is not opened in any editor. Remove it from the list of open files.
+      _openFiles.remove(_fileUriToIdeFile[editor.fileUri]);
+      _fileUriToIdeFile.remove(editor.fileUri);
+    }
+  }
+
+  /// Returns the file with the given URI, if it's opened in the IDE.
+  IdeFile? getFile(String fileUri) {
+    return _fileUriToIdeFile[fileUri];
+  }
+
+  /// Opens an editor for the file with the given URI at the given editor index, and
+  /// makes it the active editor.
+  ///
+  /// If the index is greater than the number of open editors, opens a new editor at
+  /// the end of the editor list.
+  Future<void> _openFile(String fileUri, int editorIndex) async {
+    final editor = IdeFileEditor(fileUri: fileUri);
+
+    // Add the editor to the list of open editors for the file.
+    if (!_fileUriToOpenedEditors.containsKey(fileUri)) {
+      _fileUriToOpenedEditors[fileUri] = [];
+    }
+    _fileUriToOpenedEditors[fileUri]!.add(editor);
+
+    // Update the editor list.
+    final newFileList = [..._editorData.value.openEditors];
+    if (editorIndex >= newFileList.length) {
+      newFileList.add(editor);
+    } else {
+      newFileList[editorIndex] = editor;
+    }
+    _editorData.value = IdeEditors(
+      openEditors: UnmodifiableListView(newFileList),
+      // Make the new editor the active editor.
+      activeEditorIndex: editorIndex,
+    );
+  }
+
+  /// Loads the file with the given URI into memory.
+  ///
+  /// If the file is already in memory, does nothing.
+  Future<IdeFile> _loadFile(String fileUri) async {
+    IdeFile? ideFile = _fileUriToIdeFile[fileUri];
+    if (ideFile != null) {
+      // The file is already in memory, return the existing file.
+      return ideFile;
+    }
+
+    // The file isn't opened anywhere.
+    final file = File.fromUri(Uri.parse(fileUri));
+    final content = await file.readAsString();
+
+    ideFile = IdeFile(fileUri, content);
+
+    _openFiles.add(ideFile);
+    _fileUriToIdeFile[fileUri] = ideFile;
+
+    return ideFile;
+  }
+}
+
+/// The editors opened in the IDE and the active editor index.
+class IdeEditors {
+  IdeEditors({
+    required this.openEditors,
+    this.activeEditorIndex,
+  });
+
+  final List<IdeFileEditor> openEditors;
+  final int? activeEditorIndex;
+}
+
+/// A file opened in the IDE.
+class IdeFile {
+  IdeFile(
+    this.uri,
+    this.content,
+  );
+
+  /// The URI of the file.
+  final String uri;
+
+  /// The content of the file.
+  final String content;
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) || //
+        other is IdeFile && runtimeType == other.runtimeType && uri == other.uri;
+  }
+
+  @override
+  int get hashCode => uri.hashCode;
+}
+
+/// An editor opened in the IDE.
+class IdeFileEditor {
+  IdeFileEditor({
+    required this.fileUri,
+  });
+
+  final String fileUri;
+}

--- a/example/lib/ide/problems_panel/problems_panel.dart
+++ b/example/lib/ide/problems_panel/problems_panel.dart
@@ -8,11 +8,9 @@ class ProblemsPanel extends StatefulWidget {
   const ProblemsPanel({
     super.key,
     required this.lspClient,
-    this.sourceFile,
   });
 
   final LspClient lspClient;
-  final File? sourceFile;
 
   @override
   State<ProblemsPanel> createState() => _ProblemsPanelState();
@@ -60,16 +58,11 @@ class _ProblemsPanelState extends State<ProblemsPanel> {
       return const SizedBox();
     }
 
-    // The LspClient will send problem notifications for all types of files.
-    // We only want to display them for the currently selected file.
-    if (_uri == null || widget.sourceFile == null) {
-      return const SizedBox();
-    }
-    final sameFile = _uri!.endsWith(widget.sourceFile!.path);
-    if (!sameFile) {
+    if (_uri == null) {
       return const SizedBox();
     }
 
+    // TODO: show a tree with all the diagnostics grouped by file.
     return ListView.builder(
       itemCount: _diagnostics!.length,
       itemBuilder: (context, index) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'dart:ui';
 
 import 'package:example/ide/ide.dart';
+import 'package:example/ide/ide_controller.dart';
 import 'package:example/ide/infrastructure/user_settings.dart';
 import 'package:example/ide/workspace.dart';
 import 'package:file_picker/file_picker.dart';
@@ -33,6 +34,7 @@ class _Screen extends StatefulWidget {
 
 class _ScreenState extends State<_Screen> {
   late final Workspace _workspace;
+  final IdeController _ideController = IdeController();
 
   final setupNotifier = ValueNotifier(SetupState.start);
 
@@ -74,6 +76,7 @@ class _ScreenState extends State<_Screen> {
           case SetupState.showIde:
             return IDE(
               workspace: _workspace,
+              controller: _ideController,
             );
         }
       },

--- a/example/test/lsp/lsp_test.dart
+++ b/example/test/lsp/lsp_test.dart
@@ -49,6 +49,8 @@ void main() {
       'Wrap with StreamBuilder',
       'Wrap with Center',
       'Wrap with Container',
+      'Wrap with Expanded',
+      'Wrap with Flexible',
       'Wrap with Padding',
       'Wrap with SizedBox',
       'Wrap with Column',


### PR DESCRIPTION
Add option to open multiple tabs (Resolves #23)

It's common for IDE's to allow opening multiple files in tabs. This PR adds the initial ability to do that in inception. It does not add the functionality to open side-by-side tabs, but it's something to keep in mind.

In this PR, a single click opens a file in the active tab, and a double click opens a file in a new tab. This can be changed later.

This PR introduces a `IdeController` class to hold the state of the IDE. For now it only holds the open file editors, but I think that when we implement editable files we can use this class to dispatch edit commands, like inserting text, renaming files, saving files, etc.


https://github.com/user-attachments/assets/2df5bd68-a98e-4500-bd01-557157248cec




