### PR TITLE
CodeEditor widget now supports basic text editing

### DIFF
--- a/.run/Dart Editor.run.xml
+++ b/.run/Dart Editor.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Dart Editor" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="filePath" value="$PROJECT_DIR$/example/lib/main_dart_editor.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/example/lib/main_dart_editor.dart
+++ b/example/lib/main_dart_editor.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:inception/inception.dart';
+import 'package:inception/language_dart.dart';
+
+void main() {
+  InceptionLog.initLoggers({
+    InceptionLog.input,
+  }, Level.ALL);
+
+  runApp(const _DartEditorApp());
+}
+
+class _DartEditorApp extends StatefulWidget {
+  const _DartEditorApp();
+
+  @override
+  State<_DartEditorApp> createState() => _DartEditorAppState();
+}
+
+class _DartEditorAppState extends State<_DartEditorApp> {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      theme: ThemeData(brightness: Brightness.dark),
+      home: Scaffold(
+        body: Column(
+          children: [
+            Container(
+              height: 56,
+              color: const Color(0xFF222222),
+            ),
+            const Expanded(
+              child: DartEditor(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -27,9 +27,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
-  url_launcher_macos: 5f437abeda8c85500ceb03f5c1938a8c5a705399
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
+  url_launcher_macos: de10e46d8d8b9e3a7b8a133e8de92b104379f05e
 
 PODFILE CHECKSUM: 0d3963a09fc94f580682bd88480486da345dc3f0
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -77,8 +77,13 @@ flutter:
   fonts:
     - family: SourceCodePro
       fonts:
-        - asset: assets/fonts/Source_Code_Pro/SourceCodePro-VariableFont_wght.ttf
-        - asset: assets/fonts/Source_Code_Pro/SourceCodePro-Italic-VariableFont_wght.ttf
+        - asset: assets/fonts/Source_Code_Pro/static/SourceCodePro-Regular.ttf
+        - asset: assets/fonts/Source_Code_Pro/static/SourceCodePro-Italic.ttf
+          style: italic
+        - asset: assets/fonts/Source_Code_Pro/static/SourceCodePro-Bold.ttf
+          weight: 700
+        - asset: assets/fonts/Source_Code_Pro/static/SourceCodePro-BoldItalic.ttf
+          weight: 700
           style: italic
   #   - family: Trajan Pro
   #     fonts:

--- a/lib/inception.dart
+++ b/lib/inception.dart
@@ -14,6 +14,8 @@ export 'src/editor/theme.dart';
 
 export 'src/infrastructure/text/code_comment_selection_rules.dart';
 
+export 'src/logging.dart';
+
 export 'src/lsp/lsp_client.dart';
 export 'src/lsp/messages/initialize.dart';
 export 'src/lsp/messages/code_actions.dart';

--- a/lib/language_dart.dart
+++ b/lib/language_dart.dart
@@ -1,5 +1,6 @@
 export 'src/languages/dart/dart_code_editor_presenter.dart';
 export 'src/languages/dart/dart_contextualizer.dart';
+export 'src/languages/dart/dart_editor.dart';
 export 'src/languages/dart/dart_lexer.dart';
 export 'src/languages/dart/dart_syntax_highlighter.dart';
 export 'src/languages/dart/dart_theme.dart';

--- a/lib/src/document/syntax_highlighter.dart
+++ b/lib/src/document/syntax_highlighter.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/painting.dart';
 import 'package:inception/src/document/code_document.dart';
 
@@ -6,7 +7,7 @@ import 'package:inception/src/document/code_document.dart';
 /// To highlight a document, and continue highlighting it when it changes, call [attachToDocument].
 ///
 /// To display the styled lines, get the [lineCount] and then query desired lines with [getStyledLineAt].
-abstract class CodeDocumentSyntaxHighlighter implements LexerTokenListener {
+abstract class CodeDocumentSyntaxHighlighter implements LexerTokenListener, ChangeNotifier {
   /// Sets the base text style, on top of which the [theme] is applied.
   ///
   /// When the base text style is changed, all syntax highlighting is re-run, recreating

--- a/lib/src/editor/code_layout.dart
+++ b/lib/src/editor/code_layout.dart
@@ -158,7 +158,7 @@ class CodeLinesState extends State<CodeLines> implements CodeLayout {
 
   @override
   CodePosition? findPositionInLineBelow(CodePosition position, {double? preferredXOffset}) {
-    if (position.line >= widget.codeLines.length || position.line < -1) {
+    if (position.line >= widget.codeLines.length - 1 || position.line < -1) {
       return null;
     }
 
@@ -213,7 +213,13 @@ class CodeLinesState extends State<CodeLines> implements CodeLayout {
       return lineLayout.findCodePositionNearestGlobalOffset(globalOffset);
     }
 
-    return (const CodePosition(0, 0), TextAffinity.downstream);
+    // Place caret at the end of the document.
+    // TODO: Create a property on CodeLineLayout for endPosition and query that instead of messing
+    //       with plain text length in styled code lines.
+    return (
+      CodePosition(widget.codeLines.length - 1, widget.codeLines.last.toPlainText().length),
+      TextAffinity.downstream,
+    );
   }
 
   @override

--- a/lib/src/languages/dart/dart_code_editor_presenter.dart
+++ b/lib/src/languages/dart/dart_code_editor_presenter.dart
@@ -9,16 +9,15 @@ class DartCodeEditorPresenter extends CodeEditorPresenter {
       : _codeLines = ValueNotifier([]),
         super(document) {
     _syntaxHighlighter.attachToDocument(document);
+    _syntaxHighlighter.addListener(_onStyledLinesChanged);
 
-    _codeLines.value = [
-      for (int i = 0; i < _syntaxHighlighter.lineCount; i += 1) //
-        _syntaxHighlighter.getStyledLineAt(i)!,
-    ];
+    _onStyledLinesChanged();
   }
 
   @override
   void dispose() {
     _syntaxHighlighter.detachFromDocument();
+    _syntaxHighlighter.removeListener(_onStyledLinesChanged);
     _codeLines.dispose();
     selection.dispose();
   }
@@ -28,4 +27,11 @@ class DartCodeEditorPresenter extends CodeEditorPresenter {
   final ValueNotifier<List<TextSpan>> _codeLines;
 
   final CodeDocumentSyntaxHighlighter _syntaxHighlighter;
+
+  void _onStyledLinesChanged() {
+    _codeLines.value = [
+      for (int i = 0; i < _syntaxHighlighter.lineCount; i += 1) //
+        _syntaxHighlighter.getStyledLineAt(i)!,
+    ];
+  }
 }

--- a/lib/src/languages/dart/dart_editor.dart
+++ b/lib/src/languages/dart/dart_editor.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/widgets.dart';
+import 'package:inception/src/document/code_document.dart';
+import 'package:inception/src/editor/code_editor.dart';
+import 'package:inception/src/languages/dart/dart_code_editor_presenter.dart';
+import 'package:inception/src/languages/dart/dart_lexer.dart';
+import 'package:inception/src/languages/dart/dart_syntax_highlighter.dart';
+import 'package:inception/src/languages/dart/dart_theme_pineapple.dart';
+
+/// A simplistic editor, which implements the fundamentals of a Dart code editor,
+/// which is useful for demos and for testing purposes.
+class DartEditor extends StatefulWidget {
+  const DartEditor({
+    super.key,
+    this.initialCode = "",
+  });
+
+  final String initialCode;
+
+  @override
+  State<DartEditor> createState() => _DartEditorState();
+}
+
+class _DartEditorState extends State<DartEditor> {
+  late final CodeEditorPresenter _presenter;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _presenter = DartCodeEditorPresenter(
+      CodeDocument(DartLexer(), widget.initialCode),
+      DartSyntaxHighlighter(
+        pineappleDartTheme,
+        _baseEditorTextStyle,
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _presenter.dispose();
+
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return CodeEditor(
+      presenter: _presenter,
+      style: CodeEditorStyle(
+        gutterColor: _editorTheme.gutterBackground,
+        gutterBorderColor: _editorTheme.gutterBorder,
+        lineBackgroundColor: _editorTheme.background,
+        indentLineColor: _editorTheme.indentLineColor,
+        // FIXME: I'm pretty sure this style should come from the theme, perhaps combined
+        // with _baseTextStyle to inherit the desired size and height.
+        baseTextStyle: TextStyle(
+          color: _editorTheme.foreground,
+          fontSize: 14,
+          fontFamily: "SourceCodePro",
+          height: _baseEditorTextStyle.height,
+        ),
+      ),
+    );
+  }
+}
+
+const _editorTheme = _EditorTheme(
+  paneColor: Color(0xFF222222),
+  paneDividerColor: Color(0xFF111111),
+  indentLineColor: Color(0xFF2A3F44),
+
+  // ─────────────────────────────────────────────
+  // Editor / UI
+  // ─────────────────────────────────────────────
+  background: Color(0xFF1B2A2F), // deep ocean night
+  foreground: Color(0xFFECE7D5), // warm sand text
+  caret: Color(0xFFFFE066), // pineapple yellow
+
+  selection: Color(0xFF2F6F7A), // ocean teal
+  inactiveSelection: Color(0xFF2A3F44),
+
+  lineHighlight: Color(0xFF22383E),
+
+  gutterBackground: Color(0xFF18262B),
+  gutterBorder: Color(0xFF2E4A50),
+  gutterForeground: Color(0xFF6FAFB7),
+
+  bracketHighlight: Color(0xFFFFE066), // pineapple accent
+  invisibleCharacters: Color(0xFF4F7D85),
+);
+
+// TODO: This was copied from Kalua - if this is generally accurate, export this from Inception
+class _EditorTheme {
+  const _EditorTheme({
+    required this.paneColor,
+    required this.paneDividerColor,
+    required this.background,
+    required this.indentLineColor,
+    required this.foreground,
+    required this.caret,
+    required this.selection,
+    required this.inactiveSelection,
+    required this.lineHighlight,
+    required this.gutterBackground,
+    required this.gutterBorder,
+    required this.gutterForeground,
+    required this.bracketHighlight,
+    required this.invisibleCharacters,
+  });
+
+  // ─────────────────────────────────────────────
+  // Editor / UI colors
+  // ─────────────────────────────────────────────
+
+  final Color paneColor;
+
+  final Color paneDividerColor;
+
+  /// Main editor background
+  final Color background;
+
+  /// The color of the vertical lines that are displayed in the editor for every
+  /// tab of distance that code sits from the gutter.
+  final Color indentLineColor;
+
+  /// Default foreground text color
+  final Color foreground;
+
+  /// Caret / cursor color
+  final Color caret;
+
+  /// Selection background
+  final Color selection;
+
+  /// Inactive selection background
+  final Color inactiveSelection;
+
+  /// Line highlight (current line)
+  final Color lineHighlight;
+
+  /// Gutter background
+  final Color gutterBackground;
+
+  final Color gutterBorder;
+
+  /// Gutter foreground (line numbers)
+  final Color gutterForeground;
+
+  /// Bracket pair highlight
+  final Color bracketHighlight;
+
+  /// Invisible characters (whitespace markers)
+  final Color invisibleCharacters;
+}
+
+const _baseEditorTextStyle = TextStyle(
+  fontFamily: "SourceCodePro",
+  fontSize: 14,
+  height: 1.4,
+);

--- a/lib/src/languages/dart/dart_syntax_highlighter.dart
+++ b/lib/src/languages/dart/dart_syntax_highlighter.dart
@@ -4,7 +4,7 @@ import 'package:inception/src/document/lexing.dart';
 import 'package:inception/src/document/syntax_highlighter.dart';
 import 'package:inception/src/languages/dart/dart_theme.dart';
 
-class DartSyntaxHighlighter implements CodeDocumentSyntaxHighlighter {
+class DartSyntaxHighlighter with ChangeNotifier implements CodeDocumentSyntaxHighlighter {
   DartSyntaxHighlighter(this._theme, this._baseTextStyle) {
     _genericStyles = {
       SyntaxKind.keyword: _theme.keyword,
@@ -79,38 +79,27 @@ class DartSyntaxHighlighter implements CodeDocumentSyntaxHighlighter {
   @override
   void onTokensChanged(int start, int end, List<LexerToken> newTokens) {
     final doc = _attachedDocument;
-    if (doc == null) return;
+    if (doc == null) {
+      return;
+    }
 
     final startLine = doc.offsetToCodePosition(start).line;
     final endLine = doc.offsetToCodePosition(end).line;
 
-    final oldLineCount = _lineSpans.length;
-    final newLineCount = doc.lineCount;
-    final lineDelta = newLineCount - oldLineCount;
+    // If line count changed → rebuild everything
+    if (_lineSpans.length != doc.lineCount) {
+      _rebuildAllLines();
+      return;
+    }
 
-    // Rebuild affected lines
-    final rebuiltSpans = <TextSpan>[];
-    for (int lineIndex = startLine; lineIndex <= endLine; lineIndex++) {
-      if (lineIndex >= 0 && lineIndex < newLineCount) {
-        rebuiltSpans.add(_buildLineSpan(doc, lineIndex));
+    // Otherwise rebuild only affected lines
+    for (int line = startLine; line <= endLine; line++) {
+      if (line >= 0 && line < _lineSpans.length) {
+        _lineSpans[line] = _buildLineSpan(doc, line);
       }
     }
 
-    final removeCount = endLine - startLine + 1;
-    _lineSpans.replaceRange(
-      startLine,
-      startLine + removeCount.clamp(0, _lineSpans.length - startLine),
-      rebuiltSpans,
-    );
-
-    // Adjust for line insertions/deletions
-    if (lineDelta > 0) {
-      for (int i = 0; i < lineDelta; i++) {
-        _lineSpans.insert(endLine + 1 + i, _buildLineSpan(doc, endLine + 1 + i));
-      }
-    } else if (lineDelta < 0) {
-      _lineSpans.removeRange(newLineCount, oldLineCount);
-    }
+    notifyListeners();
   }
 
   void _rebuildAllLines() {
@@ -121,6 +110,8 @@ class DartSyntaxHighlighter implements CodeDocumentSyntaxHighlighter {
     for (int i = 0; i < doc.lineCount; i++) {
       _lineSpans.add(_buildLineSpan(doc, i));
     }
+
+    notifyListeners();
   }
 
   // ---------------------
@@ -188,7 +179,7 @@ class DartSyntaxHighlighter implements CodeDocumentSyntaxHighlighter {
   TextSpan _buildLineSpan(CodeDocument doc, int lineIndex) {
     final text = doc.text;
     final lineStart = doc.getLineStart(lineIndex);
-    final lineEnd = (lineIndex + 1 < doc.lineCount) ? doc.getLineStart(lineIndex + 1) : text.length;
+    final lineEnd = doc.getLineEnd(lineIndex);
 
     final lineTokens = doc.tokensInRange(lineStart, lineEnd);
 
@@ -196,51 +187,54 @@ class DartSyntaxHighlighter implements CodeDocumentSyntaxHighlighter {
     int lastOffset = lineStart;
 
     for (final token in lineTokens) {
+      // Clip the token to the current line
       final clippedStart = token.start.clamp(lineStart, lineEnd);
       final clippedEnd = token.end.clamp(lineStart, lineEnd);
 
+      // Skip empty spans
       if (clippedStart >= clippedEnd) continue;
 
-      // Add unstyled gap text
+      // Add any unstyled text between last token and current token,
+      // but give it an explicit default style so rendering can't "inherit".
       if (clippedStart > lastOffset) {
-        spans.add(TextSpan(
-          text: text.substring(lastOffset, clippedStart),
-          style: _baseTextStyle,
-        ));
+        final gapText = text.substring(lastOffset, clippedStart);
+        spans.add(TextSpan(text: gapText, style: _baseTextStyle));
       }
 
+      // Token text
       final tokenText = text.substring(clippedStart, clippedEnd);
 
+      // Decide token style: base tokenKind style, possibly overridden by token text.
       TextStyle tokenKindStyle = _genericStyles[token.kind] ?? _theme.baseTextStyle;
 
-      // Highlight built-in types
+      // If tokenizer labeled this as an identifier but its literal text is a builtin type
+      // color it like a number/type.
       if (token.kind == SyntaxKind.identifier && _builtinTypes.contains(tokenText)) {
-        tokenKindStyle = _genericStyles[SyntaxKind.number]!; // or another existing kind
+        tokenKindStyle = _genericStyles[SyntaxKind.number]!;
       }
 
-      // Highlight keywords
-      if (token.kind == SyntaxKind.identifier && _builtinKeywords.contains(tokenText)) {
+      // Also highlight the token "type" as a keyword-ish indicator if it appears.
+      if (token.kind == SyntaxKind.identifier && tokenText == 'type') {
         tokenKindStyle = _genericStyles[SyntaxKind.keyword]!;
       }
 
-      // Merge with default style
+      // Ensure the final style explicitly sets color (merge with default)
       final effectiveStyle = _baseTextStyle.merge(tokenKindStyle);
 
-      spans.add(TextSpan(
-        text: tokenText.replaceAll('\n', ''),
-        style: effectiveStyle,
-      ));
+      spans.add(TextSpan(text: tokenText.replaceAll('\n', ''), style: effectiveStyle));
 
       lastOffset = clippedEnd;
     }
 
+    // Add remaining text at the end of the line, if any (with explicit default style)
     if (lastOffset < lineEnd) {
-      spans.add(TextSpan(
-        text: text.substring(lastOffset, lineEnd),
-        style: _baseTextStyle,
-      ));
+      final trailing = text.substring(lastOffset, lineEnd);
+      spans.add(TextSpan(text: trailing, style: _baseTextStyle));
     }
 
+    // IMPORTANT: do NOT supply a `style:` on the parent TextSpan.
+    // Parent style would be inherited by children that lack style and may cause
+    // unintended uniform coloring. Each child has an explicit style above.
     return TextSpan(children: spans);
   }
 }

--- a/lib/src/languages/dart/dart_theme_pineapple.dart
+++ b/lib/src/languages/dart/dart_theme_pineapple.dart
@@ -2,9 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:inception/src/languages/dart/dart_theme.dart';
 
 final pineappleDartTheme = DartTheme(
-  // Base text: warm, dark brown (excellent contrast on light backgrounds)
   baseTextStyle: const TextStyle(
-    color: Color(0xFF3A2E1F), // deep warm brown
+    color: Color(0xFFECE7D5),
     fontSize: 14,
     height: 1.4,
   ),
@@ -23,7 +22,7 @@ final pineappleDartTheme = DartTheme(
 
   // Identifiers: variables, functions, class names
   identifier: const TextStyle(
-    color: Color(0xFF3A2E1F), // same as base text for calm readability
+    color: Color(0xFFECE7D5),
   ),
 
   // Strings
@@ -49,7 +48,7 @@ final pineappleDartTheme = DartTheme(
 
   // Punctuation: {} () [] , ;
   punctuation: const TextStyle(
-    color: Color(0xFF5C4A32),
+    color: Color(0xFF7CD992),
   ),
 
   // Whitespace (usually invisible, but keep defined)

--- a/lib/src/logging.dart
+++ b/lib/src/logging.dart
@@ -1,0 +1,67 @@
+import 'package:logging/logging.dart';
+
+export 'package:logging/logging.dart' show Level;
+
+abstract class InceptionLog {
+  static final ux = Logger("inception.ux");
+  static final gestures = Logger("inception.ux.gestures");
+  static final input = Logger("inception.ux.input");
+
+  static final _activeLoggers = <Logger>{};
+
+  /// Send log output from all loggers, at or above the given [level], to the terminal.
+  static void initAllLogs([Level level = Level.INFO]) {
+    initLoggers({Logger.root}, level);
+  }
+
+  /// Send output from the given [loggers], at or above the given [level], to the terminal.
+  static void initLoggers(Set<Logger> loggers, [Level level = Level.INFO]) {
+    hierarchicalLoggingEnabled = true;
+
+    for (final logger in loggers) {
+      if (!_activeLoggers.contains(logger)) {
+        print('Initializing logger: ${logger.name}');
+        logger
+          ..level = level
+          ..onRecord.listen(_printLog);
+
+        _activeLoggers.add(logger);
+      } else {
+        // The logger is already active. Adjust the log level as desired.
+        logger.level = level;
+      }
+    }
+  }
+
+  /// Returns `true` if the given [logger] is currently logging, or
+  /// `false` otherwise.
+  ///
+  /// Generally, developers should call loggers, regardless of whether
+  /// a given logger is active. However, sometimes you may want to log
+  /// information that's costly to compute. In such a case, you can
+  /// choose to compute the expensive information only if the given
+  /// logger will actually log the information.
+  static bool isLogActive(Logger logger) {
+    return _activeLoggers.contains(logger);
+  }
+
+  /// Stop the given [loggers] from sending any output to the terminal.
+  static void deactivateLoggers(Set<Logger> loggers) {
+    for (final logger in loggers) {
+      if (_activeLoggers.contains(logger)) {
+        print('Deactivating logger: ${logger.name}');
+        logger.clearListeners();
+
+        _activeLoggers.remove(logger);
+      }
+    }
+  }
+
+  static void _printLog(LogRecord record) {
+    print(
+      '(${record.time.second}.${record.time.millisecond.toString().padLeft(3, '0')}) ${record.loggerName} > ${record.level.name}: ${record.message}',
+    );
+  }
+
+  const InceptionLog._();
+}

--- a/lib/src/test/code_editor/code_editor_operations.dart
+++ b/lib/src/test/code_editor/code_editor_operations.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor/super_editor_test.dart';
+
+class CodeEditorOperationList {
+  const CodeEditorOperationList(this._operations);
+
+  final List<CodeEditorOperation> _operations;
+
+  Future<void> run(WidgetTester tester) async {
+    for (final operation in _operations) {
+      await operation.run(tester);
+    }
+  }
+}
+
+class TypeTextOperation implements CodeEditorOperation {
+  const TypeTextOperation(this._text);
+
+  final String _text;
+
+  @override
+  Future<void> run(WidgetTester tester) async {
+    for (final character in _text.characters) {
+      await tester.typeImeText(character);
+    }
+  }
+}
+
+class PressKeysOperation implements CodeEditorOperation {
+  const PressKeysOperation.shift(this._key)
+      : _pressShift = true,
+        _pressMeta = false,
+        _pressAltOption = false;
+
+  const PressKeysOperation.cmd(this._key)
+      : _pressMeta = true,
+        _pressShift = false,
+        _pressAltOption = false;
+
+  const PressKeysOperation.alt(this._key)
+      : _pressAltOption = true,
+        _pressShift = false,
+        _pressMeta = false;
+
+  const PressKeysOperation(
+    this._key, {
+    bool pressShift = false,
+    bool pressMeta = false,
+    bool pressAltOption = false,
+  })  : _pressShift = pressShift,
+        _pressMeta = pressMeta,
+        _pressAltOption = pressAltOption;
+
+  final LogicalKeyboardKey _key;
+  final bool _pressShift;
+  final bool _pressMeta;
+  final bool _pressAltOption;
+
+  @override
+  Future<void> run(WidgetTester tester) async {
+    // Press down the modifier key(s).
+    if (_pressShift) {
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+    }
+    if (_pressMeta) {
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.meta);
+    }
+    if (_pressAltOption) {
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.alt);
+    }
+
+    // Press and release the primary key.
+    await tester.sendKeyEvent(_key);
+
+    // Release the modifier key(s).
+    if (_pressShift) {
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+    }
+    if (_pressMeta) {
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.meta);
+    }
+    if (_pressAltOption) {
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.alt);
+    }
+  }
+}
+
+abstract class CodeEditorOperation {
+  Future<void> run(WidgetTester tester);
+}

--- a/lib/src/test/code_editor/code_editor_presenters_for_tests.dart
+++ b/lib/src/test/code_editor/code_editor_presenters_for_tests.dart
@@ -31,6 +31,9 @@ class TestCodeEditorPresenter implements CodeEditorPresenter {
   int get lineCount => codeLines.value.length;
 
   @override
+  String getLine(int lineIndex) => codeLines.value[lineIndex].toPlainText();
+
+  @override
   int getLineLength(int lineIndex) => codeLines.value[lineIndex].toPlainText().length;
 
   @override
@@ -75,4 +78,24 @@ class TestCodeEditorPresenter implements CodeEditorPresenter {
     CodePosition searchStart, {
     bool expand = false,
   }) {}
+
+  @override
+  void insertText(String text) {
+    // TODO: implement insertText
+  }
+
+  @override
+  void insertNewline() {
+    // TODO: implement insertNewline
+  }
+
+  @override
+  void backspace() {
+    // TODO: implement backspace
+  }
+
+  @override
+  void delete() {
+    // TODO: implement delete
+  }
 }

--- a/lib/src/test/code_editor/code_editor_test_inspector.dart
+++ b/lib/src/test/code_editor/code_editor_test_inspector.dart
@@ -4,6 +4,11 @@ import 'package:inception/src/document/selection.dart';
 import 'package:inception/src/editor/code_editor.dart';
 
 abstract class CodeEditorInspector {
+  static String findContent([Finder? finder]) {
+    final (codeEditor, _) = _findCodeEditor(finder);
+    return codeEditor.presenter.document.text;
+  }
+
   static CodeSelection? findSelection([Finder? finder]) {
     final (codeEditor, _) = _findCodeEditor(finder);
     return codeEditor.presenter.selection.value;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,11 +18,12 @@ dependencies:
   flutter_test:
     sdk: flutter
   flutter_test_runners: ^0.0.4
+  flutter_test_robots: ^0.0.24
+  logging: ^1.3.0
 
 dev_dependencies:
   flutter_lints: ^2.0.0
   fake_async: ^1.3.3
   flutter_test_goldens: ^0.0.7
-  flutter_test_robots: ^0.0.24
 
 flutter:

--- a/test/code_editor/keyboard_interactions/coed_editor_typing_test.dart
+++ b/test/code_editor/keyboard_interactions/coed_editor_typing_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_robots/flutter_test_robots.dart';
+import 'package:flutter_test_runners/flutter_test_runners.dart';
+import 'package:inception/inception.dart';
+import 'package:inception/language_dart.dart';
+import 'package:inception/src/test/code_editor/code_editor_operations.dart';
+
+void main() {
+  group("Code Editor > editing >", () {
+    testWidgetsOnMac("types a hello world document", (tester) async {
+      await _pumpScaffold(tester);
+      await tester.tap(find.byType(CodeEditor));
+
+      await _writeHelloWorldApp.run(tester);
+
+      expect(CodeEditorInspector.findContent(), _helloWorldApp);
+
+      // Expire pending timers.
+      await tester.pump(const Duration(seconds: 5));
+    });
+
+    testWidgetsOnMac("can delete entire hello world document", (tester) async {
+      await _pumpScaffold(tester, code: _helloWorldApp);
+
+      // Place caret at start of document.
+      await tester.clickOnCodePosition(0, 0, affinity: TextAffinity.upstream);
+
+      // Ensure we're starting with full "hello, world" document.
+      expect(CodeEditorInspector.findContent(), _helloWorldApp);
+
+      // Delete every character, one by one.
+      for (int i = 0; i < _helloWorldApp.length; i += 1) {
+        await tester.pressDelete();
+      }
+
+      // Ensure we deleted everything.
+      expect(CodeEditorInspector.findContent(), "");
+
+      // Expire pending timers.
+      await tester.pump(const Duration(seconds: 5));
+    });
+
+    testWidgetsOnMac("can backspace entire hello world document", (tester) async {
+      await _pumpScaffold(tester, code: _helloWorldApp);
+
+      // Place caret at end of the document.
+      await tester.tap(find.byType(CodeEditor));
+
+      // Ensure we're starting with full "hello, world" document.
+      expect(CodeEditorInspector.findContent(), _helloWorldApp);
+
+      // Delete every character, one by one.
+      for (int i = 0; i < _helloWorldApp.length; i += 1) {
+        await tester.pressBackspace();
+      }
+
+      // Ensure we deleted everything.
+      expect(CodeEditorInspector.findContent(), "");
+
+      // Expire pending timers.
+      await tester.pump(const Duration(seconds: 5));
+    });
+
+    testWidgetsOnMac("can select all and delete hello world document", (tester) async {
+      await _pumpScaffold(tester, code: _helloWorldApp);
+
+      // Give focus to the editor.
+      await tester.tap(find.byType(CodeEditor));
+
+      // Ensure we're starting with full "hello, world" document.
+      expect(CodeEditorInspector.findContent(), _helloWorldApp);
+
+      // Select all.
+      await tester.pressCmdA();
+
+      // Delete the selection.
+      await tester.pressBackspace();
+
+      // Ensure we deleted everything.
+      expect(CodeEditorInspector.findContent(), "");
+
+      // Expire pending timers.
+      await tester.pump(const Duration(seconds: 5));
+    });
+  });
+}
+
+const _writeHelloWorldApp = CodeEditorOperationList([
+  TypeTextOperation("void main() {"),
+  PressKeysOperation(LogicalKeyboardKey.enter),
+  TypeTextOperation("  print('Hello, World!');"),
+  PressKeysOperation(LogicalKeyboardKey.enter),
+  TypeTextOperation("}"),
+]);
+
+const _helloWorldApp = '''
+void main() {
+  print('Hello, World!');
+}''';
+
+Future<void> _pumpScaffold(
+  WidgetTester tester, {
+  String code = "",
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: DartEditor(
+          initialCode: code,
+        ),
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
CodeEditor widget now supports basic text editing
 - CodeEditor now implements DeltaTextInputClient
 - CodeEditor implements ImeInputOwner for test robots
 - Added tests that type each character in a hello world document, deletes every character, and selects all and deletes


https://github.com/user-attachments/assets/b8e9d2d4-4127-4445-a15f-8653bcd1bcb4

